### PR TITLE
GitHub/71

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
   # Prevent TTY Errors (copied from laravel/homestead: "homestead.rb" file)...
   # By default this is "bash -l".
   config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
@@ -22,7 +22,7 @@ Vagrant.configure(2) do |config|
   if ENV['DEV']
     config.vm.provision "shell", path: 'scripts/setup/vagrant_dev_provisioning.sh', privileged: false
   end
-  
+
   # Relocate the log file to the temp folder
   config.vm.provider "virtualbox" do |vb|
     vb.customize [

--- a/scripts/setup/vagrant_provisioning1.sh
+++ b/scripts/setup/vagrant_provisioning1.sh
@@ -49,4 +49,4 @@ apt-get install libapache2-mod-wsgi-py3
 service apache2 restart
 
 # Upgrade pip to latest version
-pip install --upgrade pip
+pip3 install --upgrade pip

--- a/scripts/setup/vagrant_provisioning1.sh
+++ b/scripts/setup/vagrant_provisioning1.sh
@@ -34,10 +34,10 @@ sudo -u postgres  sh -c 'psql d2qc -c "CREATE EXTENSION postgis;"'
 
 
 # Install Python, pip, virtualenv
-apt-get install -y python-pip
-apt-get install -y python-dev
+apt-get install -y python3-pip
 apt-get install -y python3-dev
 apt-get install -y python3-tk
+apt-get install -y python3-venv
 
 # Install GEOS for matplotlib
 apt-get install -y libgeos-c1v5 libgeos-dev

--- a/scripts/setup/vagrant_provisioning1.sh
+++ b/scripts/setup/vagrant_provisioning1.sh
@@ -13,7 +13,6 @@ cd /vagrant
 # Prevent errors trying to access stdin
 export DEBIAN_FRONTEND=noninteractive
 
-add-apt-repository -y ppa:ubuntugis/ppa
 apt-get update
 apt-get upgrade -y
 

--- a/scripts/setup/vagrant_provisioning2.sh
+++ b/scripts/setup/vagrant_provisioning2.sh
@@ -18,11 +18,9 @@ git submodule update
 echo 'PATH="$PATH:/home/vagrant/.local/bin"' >> ~/.profile
 source ~/.profile
 
-
-if [ ! -d .env_vagrant ]
-then
-  python3 -m venv .env_vagrant
-fi
+# Remove possibly existing environment folder
+rm -rf .env_vagrant
+python3 -m venv .env_vagrant
 
 source .env_vagrant/bin/activate
 

--- a/scripts/setup/vagrant_provisioning2.sh
+++ b/scripts/setup/vagrant_provisioning2.sh
@@ -24,7 +24,7 @@ python -m pip install --user virtualenv
 
 if [ ! -d .env_vagrant ]
 then
-  virtualenv -p python3 --no-site-packages .env_vagrant
+  python3 -m venv .env_vagrant
 fi
 
 source .env_vagrant/bin/activate

--- a/scripts/setup/vagrant_provisioning2.sh
+++ b/scripts/setup/vagrant_provisioning2.sh
@@ -18,9 +18,6 @@ git submodule update
 echo 'PATH="$PATH:/home/vagrant/.local/bin"' >> ~/.profile
 source ~/.profile
 
-# Install Virtualenv
-python -m pip install --user virtualenv
-
 
 if [ ! -d .env_vagrant ]
 then


### PR DESCRIPTION
Minor changes to vagrant provisioning scripts to support ubuntu 18.04. 

To test destroy your current virtual machine, then run vagrant up: 

```
vagrant destroy 
vagrant up
```

Notify red lines during vagrant provisioning 

Close #71 