### PR TITLE
(#83) Create a user profile for the admin user

### DIFF
--- a/d2qc/d2qc/data/management/commands/add_dev_admin_user.py
+++ b/d2qc/d2qc/data/management/commands/add_dev_admin_user.py
@@ -1,4 +1,5 @@
-from django.contrib.auth import get_user_model;
+from django.contrib.auth import get_user_model
+from d2qc.data.models import Profile
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
@@ -27,3 +28,6 @@ class Command(BaseCommand):
         admin.set_password(settings.DEV_ADMIN_PROPERTIES['password'])
         admin.email = settings.DEV_ADMIN_PROPERTIES['email']
         admin.save()
+        admin.profile = Profile(user=admin)
+        admin.profile.save()
+

--- a/d2qc/d2qc/data/management/commands/add_dev_admin_user.py
+++ b/d2qc/d2qc/data/management/commands/add_dev_admin_user.py
@@ -27,7 +27,5 @@ class Command(BaseCommand):
         admin.is_staff = True
         admin.set_password(settings.DEV_ADMIN_PROPERTIES['password'])
         admin.email = settings.DEV_ADMIN_PROPERTIES['email']
+        admin.profile, created = Profile.objects.get_or_create(user=admin)
         admin.save()
-        admin.profile = Profile(user=admin)
-        admin.profile.save()
-


### PR DESCRIPTION
User profiles are created automatically for new sign-ups. It was just the admin user that was missing one. Now it gets created in the provisioning script.