### PR TITLE
(#73) Fix crossover station selection

### DIFF
--- a/d2qc/d2qc/data/management/commands/db_restore_from_prod.py
+++ b/d2qc/d2qc/data/management/commands/db_restore_from_prod.py
@@ -70,6 +70,12 @@ class Command(BaseCommand):
         os.system(cmd)
 
         # Get db backup file
+        if os.path.isfile(backup_folder):
+            os.remove(backup_folder)
+
+        if not os.path.exists(backup_folder):
+            os.mkdir(backup_folder)
+
         if os.path.islink(backup_db_file):
             os.remove(backup_db_file)
 

--- a/d2qc/d2qc/data/models.py
+++ b/d2qc/d2qc/data/models.py
@@ -234,6 +234,7 @@ class DataSet(models.Model):
         retval = cursor.fetchall()[0][0]
         self._stations[query_key] = retval
         return retval if retval else '-1'
+
     def _get_first_sql_result(self, sql):
         """Get the first result of the passed sql query as a string."""
 
@@ -364,7 +365,7 @@ class DataSet(models.Model):
         """
         sql = """
             select ds.id, ds.expocode,
-            count(st.id) as station_count,
+            count(distinct st.id) as station_count,
             min(d.date_and_time) as first_station
             from d2qc_stations st
             inner join d2qc_data_sets ds on (st.data_set_id = ds.id)

--- a/d2qc/d2qc/data/templates/data/dataset_detail.html
+++ b/d2qc/d2qc/data/templates/data/dataset_detail.html
@@ -139,8 +139,8 @@ src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v5.3.
             var raster = new ol.layer.Tile({
                 source: new ol.source.OSM()
             });
-            var stations = '{{ stations }}';
-            var crossovers = '{{ crossovers }}';
+            var stations = '{{ station_positions }}';
+            var crossovers = '{{ crossover_positions }}';
             var stations_polygon = '{{ stations_polygon }}'
             var features = []
             red = new ol.style.Style({


### PR DESCRIPTION
In doing this I've revised the approach to the SQL queries used. Instead of all queries using the `_in_stations` function to work out which stations to use, the first functions now collect the stations to be used and pass those into subsequent functions. There are two reasons I did this:

1. The `in_stations` function was very hard to follow (especially when it started recursing) and I couldn't work out where the bug was happening.
2. This approach should be faster, because the set of stations is only calculated once and then used as a simple filter subsequently.

Note that for PHSPHT, the number of blue stations selected is different from the previous version. As far as I can tell from looking at the underlying data this is correct, but I could have misunderstood something.